### PR TITLE
Add Loop v3.4 support

### DIFF
--- a/GlucoseDirectClientUI/GlucoseDirectManager+UI.swift
+++ b/GlucoseDirectClientUI/GlucoseDirectManager+UI.swift
@@ -23,12 +23,18 @@ extension GlucoseDirectManager: CGMManagerUI {
         return UIImage(named: "glucose-direct", in: FrameworkBundle.own, compatibleWith: nil)!
     }
 
-    public static func setupViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool) -> SetupUIResult<CGMManagerViewController, CGMManagerUI> {
+    public static func setupViewController(
+        bluetoothProvider: BluetoothProvider,
+        displayGlucosePreference: DisplayGlucosePreference,
+        colorPalette: LoopUIColorPalette,
+        allowDebugFeatures: Bool,
+        prefersToSkipUserInteraction: Bool
+    ) -> SetupUIResult<CGMManagerViewController, CGMManagerUI> {
         return .createdAndOnboarded(GlucoseDirectManager())
     }
 
-    public func settingsViewController(bluetoothProvider: BluetoothProvider, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool) -> CGMManagerViewController {
-        let settings = GlucoseDirectSettingsViewController(cgmManager: self, displayGlucoseUnitObservable: displayGlucoseUnitObservable)
+    public func settingsViewController(bluetoothProvider: BluetoothProvider, displayGlucosePreference: DisplayGlucosePreference, colorPalette: LoopUIColorPalette, allowDebugFeatures: Bool) -> CGMManagerViewController {
+        let settings = GlucoseDirectSettingsViewController(cgmManager: self, displayGlucosePreference: displayGlucosePreference)
         let nav = CGMManagerSettingsNavigationViewController(rootViewController: settings)
 
         return nav

--- a/GlucoseDirectClientUI/GlucoseDirectSettingsViewController.swift
+++ b/GlucoseDirectClientUI/GlucoseDirectSettingsViewController.swift
@@ -14,9 +14,9 @@ import LoopKitUI
 public class GlucoseDirectSettingsViewController: UITableViewController {
     // MARK: Lifecycle
 
-    init(cgmManager: GlucoseDirectManager, displayGlucoseUnitObservable: DisplayGlucoseUnitObservable) {
+    init(cgmManager: GlucoseDirectManager, displayGlucosePreference: DisplayGlucosePreference) {
         self.cgmManager = cgmManager
-        self.glucoseUnit = displayGlucoseUnitObservable
+        self.glucoseUnit = displayGlucosePreference
 
         super.init(style: .grouped)
         title = LocalizedString("CGM Settings")
@@ -112,7 +112,7 @@ public class GlucoseDirectSettingsViewController: UITableViewController {
                 case .glucose:
                     let cell = tableView.dequeueReusableCell(withIdentifier: "value", for: indexPath) as! ValueStyleCell
                     cell.textLabel?.text = LocalizedString("Glucose")
-                    cell.detailTextLabel?.text = quantityFormatter.string(from: latestGlucoseSample.quantity, for: glucoseUnit.displayGlucoseUnit)
+                    cell.detailTextLabel?.text = quantityFormatter.string(from: latestGlucoseSample.quantity, includeUnit: true)
 
                     return cell
                 case .trend:
@@ -196,7 +196,7 @@ public class GlucoseDirectSettingsViewController: UITableViewController {
 
     // MARK: Internal
 
-    let glucoseUnit: DisplayGlucoseUnitObservable
+    let glucoseUnit: DisplayGlucosePreference
     let cgmManager: GlucoseDirectManager
 
     @objc func doneTapped(_ sender: Any) {
@@ -241,7 +241,7 @@ public class GlucoseDirectSettingsViewController: UITableViewController {
     private var appLogo: UIImage? = UIImage(named: "glucose-direct", in: FrameworkBundle.own, compatibleWith: nil)!.imageWithInsets(insets: UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0))
 
     private var quantityFormatter: QuantityFormatter {
-        return QuantityFormatter()
+        return QuantityFormatter(for: .internationalUnit())
     }
 
     private var dateFormatter: DateFormatter {


### PR DESCRIPTION
This draft PR replaces `DisplayGlucoseUnitObservable` with `DisplayGlucosePreference`.
The main motivation is to get Libre 3 to work with Loop 3.4 (via LibreLinkUp credentials)

### Blocked by
- [ ] Test it