### PR TITLE
Enable syncing GCM readings with Services

### DIFF
--- a/GlucoseDirectClient/GlucoseDirectManager.swift
+++ b/GlucoseDirectClient/GlucoseDirectManager.swift
@@ -22,7 +22,7 @@ public class GlucoseDirectManager: CGMManager {
 
     public required convenience init?(rawState: CGMManager.RawStateValue) {
         self.init()
-        shouldSyncToRemoteService = rawState[Config.shouldSyncKey] as? Bool ?? false
+        // shouldSyncToRemoteService = rawState[Config.shouldSyncKey] as? Bool ?? true
     }
 
     // MARK: Public
@@ -35,7 +35,7 @@ public class GlucoseDirectManager: CGMManager {
     public let providesBLEHeartbeat = false
 
     public var managedDataInterval: TimeInterval?
-    public var shouldSyncToRemoteService = false
+    public var shouldSyncToRemoteService = true
     public private(set) var latestGlucose: ClientGlucose?
     public private(set) var latestGlucoseSample: NewGlucoseSample?
 


### PR DESCRIPTION
For someone this is set to disabled, which causes GCM readings not to be uploaded to services like Tidepool or Nightscout.

If this is because one may be uploading from Libre to these services already directly, this should be turned into a setting that can be toggled from the settings view.